### PR TITLE
Implement dynamic menu tabs based on OGC API landing page links

### DIFF
--- a/components/layout/default/Header.vue
+++ b/components/layout/default/Header.vue
@@ -72,23 +72,23 @@
   <div class="col-auto">
     <q-tabs dense align="left">
       <q-route-tab
-        v-for="tab in leftTabs"
+        v-for="tab in homeTab"
         :key="tab.path"
-        no-caps
-        :to="tab.path"
+        :href="tab.path"
         :label="t(tab.label)"
+        no-caps
       />
     </q-tabs>
   </div>
   <q-space/>
   <div class="col-auto">
-    <q-tabs dense align="left">
+    <q-tabs dense align="right">
       <q-route-tab
         v-for="tab in rightTabs"
         :key="tab.path"
-        no-caps
-        :to="tab.path"
         :label="t(tab.label)"
+        :href="tab.path"
+        no-caps
       />
     </q-tabs>
   </div>
@@ -104,7 +104,7 @@ import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useCookie } from '#app'
 import { useAuthStore } from '~/stores/auth'
-import { menuItems } from '~/composables/utils/menuItems'
+import { useLandingLinks } from '~/composables/utils/useLandingLinks'
 
 const config = useRuntimeConfig()
 const showHeaderMenu = ref(false)
@@ -113,16 +113,35 @@ const loggedUser = ref({email: 'mathereall@gmail.com'}) // TODO: Implement user 
 
 
 const authStore = useAuthStore()
-const leftTabs = computed(() => {
-  return menuItems.filter(item => !item.auth)
-})
 
-const rightTabs = computed(() => {
-  return menuItems.filter(item => item.auth && authStore.user)
-})
+
+const { landingLinks } = useLandingLinks()
+
+function autoLabel(href: string): string {
+  const filename = href.split('/').pop()?.replace('.html', '') || ''
+  return filename.charAt(0).toUpperCase() + filename.slice(1)
+}
+
+const homeTab = computed(() =>
+  landingLinks.value
+    .filter(link => link.href && link.href.endsWith('index.html'))
+    .map(link => ({
+      path: link.href,
+      label: 'Home'
+    }))
+)
+
+const rightTabs = computed(() =>
+  landingLinks.value
+    .filter(link => link.href && link.href.endsWith('.html') && !link.href.endsWith('index.html'))
+    .map(link => ({
+      path: link.href,
+      label: autoLabel(link.href)
+    }))
+)
+
 
 const { locale, t } = useI18n()
-
 
 
 const $q = useQuasar()

--- a/components/layout/quasar/Header.vue
+++ b/components/layout/quasar/Header.vue
@@ -19,23 +19,23 @@
   <div class="col-auto">
     <q-tabs dense align="left">
       <q-route-tab
-        v-for="tab in leftTabs"
+        v-for="tab in homeTab"
         :key="tab.path"
-        no-caps
-        :to="tab.path"
+        :href="tab.path"
         :label="t(tab.label)"
+        no-caps
       />
     </q-tabs>
   </div>
   <q-space/>
   <div class="col-auto">
-    <q-tabs dense align="left">
+    <q-tabs dense align="right">
       <q-route-tab
         v-for="tab in rightTabs"
         :key="tab.path"
-        no-caps
-        :to="tab.path"
         :label="t(tab.label)"
+        :href="tab.path"
+        no-caps
       />
     </q-tabs>
   </div>
@@ -50,17 +50,35 @@ import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useCookie } from '#app'
 import { useAuthStore } from '~/stores/auth'
-import { menuItems } from '~/composables/utils/menuItems'
+import { useLandingLinks } from '~/composables/utils/useLandingLinks'
 
 const { locale, t } = useI18n()
 
 const authStore = useAuthStore()
-const leftTabs = computed(() => {
-  return menuItems.filter(item => !item.auth)
-})
 
-const rightTabs = computed(() => {
-  return menuItems.filter(item => item.auth && authStore.user)
-})
+const { landingLinks } = useLandingLinks()
+
+function autoLabel(href: string): string {
+  const filename = href.split('/').pop()?.replace('.html', '') || ''
+  return filename.charAt(0).toUpperCase() + filename.slice(1)
+}
+
+const homeTab = computed(() =>
+  landingLinks.value
+    .filter(link => link.href && link.href.endsWith('index.html'))
+    .map(link => ({
+      path: link.href,
+      label: 'Home'
+    }))
+)
+
+const rightTabs = computed(() =>
+  landingLinks.value
+    .filter(link => link.href && link.href.endsWith('.html') && !link.href.endsWith('index.html'))
+    .map(link => ({
+      path: link.href,
+      label: autoLabel(link.href)
+    }))
+)
 
 </script>

--- a/composables/utils/menuItems.ts
+++ b/composables/utils/menuItems.ts
@@ -1,7 +1,0 @@
-export const menuItems = [
-    { path: '/', label: 'Home', auth: false },
-    { path: '/swagger', label: 'Swagger', auth: true },
-    { path: '/processes', label: 'Processes', auth: true },
-    { path: '/jobs', label: 'Jobs', auth: true }
-  ]
-  

--- a/composables/utils/useLandingLinks.ts
+++ b/composables/utils/useLandingLinks.ts
@@ -1,0 +1,29 @@
+import { ref, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRuntimeConfig } from '#imports'
+
+const landingLinks = ref<any[]>([]) // Keep this reactive and global
+const fetched = ref(false)
+
+export const useLandingLinks = () => {
+  const { locale } = useI18n()
+  const config = useRuntimeConfig()
+
+  const fetchLinks = async () => {
+    if (fetched.value) return // avoid duplicate calls
+
+    try {
+      const headers = { 'Accept-Language': locale.value }
+      const res = await $fetch(`${config.public.NUXT_ZOO_BASEURL}/ogc-api/`, { headers })
+      landingLinks.value = res.links || []
+      fetched.value = true
+    } catch (err) {
+      console.error('Error fetching links:', err)
+    }
+  }
+
+  onMounted(fetchLinks) // fetch when any component uses it
+
+  return {landingLinks}
+}
+

--- a/pages/processes/[processId].vue
+++ b/pages/processes/[processId].vue
@@ -240,7 +240,7 @@ const submitProcess = async () => {
       headers: {
         Authorization: `Bearer ${authStore.token.access_token}`,
         'Content-Type': 'application/json',
-        'Accept-Language': locale.value
+        'Accept-Language': locale.value,
         'Prefer': preferMode.value
       },
       body: JSON.stringify(payload)
@@ -514,6 +514,7 @@ const removeInputField = (inputId: string, index: number) => {
               </template>
             </div>
           </q-card>
+          </div>
 
       <div class="q-gutter-sm row items-center">
         <q-badge color="grey-3" text-color="black">
@@ -673,7 +674,7 @@ const removeInputField = (inputId: string, index: number) => {
           <q-btn label="Submit" type="submit" color="primary" />
           <q-btn color="primary" outline label="Show JSON Preview" @click="showDialog = true" />
         </div>
-      </q-form>
+
 
       <q-dialog v-model="showDialog" persistent>
         <q-card style="min-width: 70vw; max-width: 90vw;">


### PR DESCRIPTION
- Summary
This PR introduces a dynamic approach to rendering header menu tabs based on the links provided by the OGC API landing page (/ogc-api/). Instead of hardcoding paths such as processes, jobs, or conformance, the application now fetches and renders tabs dynamically from the backend response.

- Changes Made
> Created a composable (useLandingLinks.ts) to fetch links from the OGC API landing page
> **Updated (header.vue) to:**  
> Dynamically display the (Home) tab on the left.
> Populate the right aligned tabs using other available (.html) links from the backend.
> Automatically generate readable labels from the urls (processes.html - Processes).

Removed previous static menu implementation.
                                                     