### PR TITLE
Run nuxt-client as a non-root user

### DIFF
--- a/Dockerfile.nuxt
+++ b/Dockerfile.nuxt
@@ -24,9 +24,18 @@ RUN npm install --omit=dev
 # Construye el proyecto
 RUN npm run build
 
+# Crée un utilisateur non-root
+RUN useradd -m appuser
+
+# Corrige les permissions
+RUN chown -R appuser:appuser /usr/src/app
+
+# Passe à l'utilisateur non-root
+USER appuser
+
 # Expone el puerto de la aplicación
 EXPOSE 3000
 
 # Comando para iniciar el servidor en producción
-# CMD ["node", ".output/server/index.mjs"]
-CMD ["npm", "run", "start"]
+CMD ["node", ".output/server/index.mjs"]
+# CMD ["npm", "run", "start"]


### PR DESCRIPTION
- Added a non-root user (appuser) in the Dockerfile
- Updated file ownership using chown to ensure proper access permissions
- Switched container runtime from root to appuser
- Verified using whoami