### PR TITLE
Add a new parameter to define if IAM is activated, to bypass APISIX issues

### DIFF
--- a/components/SwaggerUI.vue
+++ b/components/SwaggerUI.vue
@@ -66,12 +66,34 @@ onMounted(async () => {
     showExtensions: true,
     showCommonExtensions: true,
     requestInterceptor: (req) => {
-      const paths = ['/api', '/me', '/jobs', '/processes', '/stac', '/raster'];
-      if (paths.some(path => req.url.includes('/ogc-api' + path))) {
-        // Add bearer token only when the user is authenticated.
+      const protectedResources = ['api', 'me', 'jobs', 'processes', 'stac', 'raster'];
+
+      let pathname = '';
+      try {
+        pathname = new URL(req.url, serverUrl).pathname;
+      } catch {
+        pathname = '';
+      }
+
+      // Support both /ogc-api/<resource> and /<namespace>/ogc-api/<resource>.
+      const shouldAttachBearer = protectedResources.some((resource) => {
+        const pattern = new RegExp(`(?:^|/)ogc-api/${resource}(?:/|$)`);
+        return pattern.test(pathname);
+      });
+
+      if (shouldAttachBearer) {
         const headers = getRequestHeaders();
-        if (config.public.ZOO_OGCAPI_REQUIRES_BEARER_TOKEN === 'true' && headers.Authorization) {
-          req.headers.Authorization = headers.Authorization;
+        if (requiresBearer && headers.Authorization) {
+          if (!req.headers) {
+            req.headers = {};
+          }
+
+          if (typeof req.headers.set === 'function') {
+            req.headers.set('Authorization', headers.Authorization);
+          } else {
+            req.headers.Authorization = headers.Authorization;
+            req.headers.authorization = headers.Authorization;
+          }
         }
       }
       return req;

--- a/components/SwaggerUI.vue
+++ b/components/SwaggerUI.vue
@@ -14,9 +14,27 @@ const { resolveOpenApiServerBase, getRequestHeaders } = useOgcApiServer();
 
 onMounted(async () => {
   const fallback = `${config.public.NUXT_ZOO_BASEURL}/ogc-api`;
+  const iamFlagRaw = config.public.ZOO_IAM_ENABLED;
+  const iamEnabled = ['true', '1', 'yes', 'on'].includes(String(iamFlagRaw).toLowerCase());
+  const requiresBearer = String(config.public.ZOO_OGCAPI_REQUIRES_BEARER_TOKEN).toLowerCase() === 'true';
+
+  // Auth state hydration can lag a bit on first page load. When bearer is
+  // required, wait briefly so the initial OpenAPI request does not get
+  // redirected to IAM (CORS failure in browser).
+  if (requiresBearer) {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < 4000) {
+      const headers = getRequestHeaders();
+      if (headers.Authorization) {
+        break;
+      }
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+  }
+
   let serverUrl;
 
-  if (config.public.ZOO_IAM_ENABLED === 'true') {
+  if (iamEnabled) {
     // IAM enabled: APISIX may protect the per-user server URL advertised
     // in the OpenAPI spec. Use the static base URL only.
     serverUrl = fallback.replace(/\/+$/, '');
@@ -26,6 +44,11 @@ onMounted(async () => {
     const serverBase = await resolveOpenApiServerBase();
     serverUrl = (serverBase || fallback).replace(/\/+$/, '');
   }
+  console.log('SwaggerUI flags', {
+    iamFlagRaw,
+    iamEnabled,
+    requiresBearer,
+  });
   console.log('SwaggerUI serverUrl', serverUrl);
 
   SwaggerUI({

--- a/components/SwaggerUI.vue
+++ b/components/SwaggerUI.vue
@@ -89,10 +89,15 @@ onMounted(async () => {
           }
 
           if (typeof req.headers.set === 'function') {
+            if (typeof req.headers.delete === 'function') {
+              req.headers.delete('authorization');
+            }
             req.headers.set('Authorization', headers.Authorization);
           } else {
             req.headers.Authorization = headers.Authorization;
-            req.headers.authorization = headers.Authorization;
+            if ('authorization' in req.headers) {
+              delete req.headers.authorization;
+            }
           }
         }
       }

--- a/components/SwaggerUI.vue
+++ b/components/SwaggerUI.vue
@@ -44,16 +44,23 @@ onMounted(async () => {
     const serverBase = await resolveOpenApiServerBase();
     serverUrl = (serverBase || fallback).replace(/\/+$/, '');
   }
-  console.log('SwaggerUI flags', {
-    iamFlagRaw,
-    iamEnabled,
-    requiresBearer,
-  });
+  console.log('SwaggerUI flags', { iamFlagRaw, iamEnabled, requiresBearer });
   console.log('SwaggerUI serverUrl', serverUrl);
+
+  // Fetch the OpenAPI spec ourselves so we can attach the bearer token —
+  // SwaggerUI's own fetch bypasses the requestInterceptor for this first call.
+  let spec;
+  try {
+    const specHeaders = getRequestHeaders();
+    console.log('SwaggerUI spec fetch headers', Object.keys(specHeaders));
+    spec = await $fetch(serverUrl + '/api', { headers: specHeaders });
+  } catch (err) {
+    console.error('SwaggerUI: failed to fetch spec', err);
+  }
 
   SwaggerUI({
     dom_id: '#swagger-ui',
-    url: serverUrl + '/api',
+    ...(spec ? { spec } : { url: serverUrl + '/api' }),
     presets: [SwaggerUI.presets.apis],
     deepLinking: true,
     showExtensions: true,

--- a/components/SwaggerUI.vue
+++ b/components/SwaggerUI.vue
@@ -13,11 +13,19 @@ const config = useRuntimeConfig();
 const { resolveOpenApiServerBase, getRequestHeaders } = useOgcApiServer();
 
 onMounted(async () => {
-  // Resolve the OGC API server base from /ogc-api/api (servers[0].url),
-  // which is the per-user URL when authenticated.
-  const serverBase = await resolveOpenApiServerBase();
   const fallback = `${config.public.NUXT_ZOO_BASEURL}/ogc-api`;
-  const serverUrl = (serverBase || fallback).replace(/\/+$/, '');
+  let serverUrl;
+
+  if (config.public.ZOO_IAM_ENABLED === 'true') {
+    // IAM enabled: APISIX may protect the per-user server URL advertised
+    // in the OpenAPI spec. Use the static base URL only.
+    serverUrl = fallback.replace(/\/+$/, '');
+  } else {
+    // No IAM: resolve the OGC API server base from /ogc-api/api
+    // (servers[0].url), which is the per-user URL when authenticated.
+    const serverBase = await resolveOpenApiServerBase();
+    serverUrl = (serverBase || fallback).replace(/\/+$/, '');
+  }
   console.log('SwaggerUI serverUrl', serverUrl);
 
   SwaggerUI({

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -76,6 +76,7 @@ export default defineNuxtConfig({
             AUTH_ORIGIN: process.env.AUTH_ORIGIN,
             NEXTAUTH_URL: process.env.NEXTAUTH_URL,
             ZOO_OGCAPI_REQUIRES_BEARER_TOKEN: process.env.ZOO_OGCAPI_REQUIRES_BEARER_TOKEN,
+            ZOO_IAM_ENABLED: process.env.ZOO_IAM_ENABLED,
             SUBSCRIBERURL: process.env.SUBSCRIBERURL,
         },
     }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -77,6 +77,7 @@ export default defineNuxtConfig({
             NEXTAUTH_URL: process.env.NEXTAUTH_URL,
             ZOO_OGCAPI_REQUIRES_BEARER_TOKEN: process.env.ZOO_OGCAPI_REQUIRES_BEARER_TOKEN,
             ZOO_IAM_ENABLED: process.env.ZOO_IAM_ENABLED,
+            NUXT_WS_URL: process.env.NUXT_WS_URL,
             SUBSCRIBERURL: process.env.SUBSCRIBERURL,
         },
     }

--- a/pages/processes/[processId].vue
+++ b/pages/processes/[processId].vue
@@ -836,10 +836,29 @@ const submitProcess = async () => {
  
     let wsUrl = "";
     if (typeof window !== "undefined") {
-      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      // Use wss or ws to access the WebSocket
-      const hostname = window.location.hostname.replace(/^webui\./, 'ws.');
-      wsUrl = `${protocol}//${hostname}/`;
+      const configuredWsUrl = String(config.public.NUXT_WS_URL || "").trim();
+
+      if (configuredWsUrl) {
+        // Accept ws://, wss:// and convert http(s):// for convenience.
+        if (configuredWsUrl.startsWith('ws://') || configuredWsUrl.startsWith('wss://')) {
+          wsUrl = configuredWsUrl;
+        } else if (configuredWsUrl.startsWith('http://')) {
+          wsUrl = `ws://${configuredWsUrl.slice('http://'.length)}`;
+        } else if (configuredWsUrl.startsWith('https://')) {
+          wsUrl = `wss://${configuredWsUrl.slice('https://'.length)}`;
+        } else {
+          wsUrl = configuredWsUrl;
+        }
+
+        if (!wsUrl.endsWith('/')) {
+          wsUrl += '/';
+        }
+      } else {
+        const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        // Use wss or ws to access the WebSocket
+        const hostname = window.location.hostname.replace(/^webui\./, 'ws.');
+        wsUrl = `${protocol}//${hostname}/`;
+      }
     }
  
   // subscriber URLs for async only


### PR DESCRIPTION
This pull request updates how the Swagger UI component determines which OGC API server base URL to use, adding support for environments with IAM (Identity and Access Management) enabled. It introduces a new environment variable to control this behavior and adjusts the logic accordingly.

Configuration and environment variable changes:

* Added the `ZOO_IAM_ENABLED` environment variable to the Nuxt public runtime config in `nuxt.config.ts`, allowing the app to detect if IAM is enabled.

Swagger UI server URL resolution logic:

* Updated `components/SwaggerUI.vue` to check if `ZOO_IAM_ENABLED` is set to `'true'`. If so, it always uses the static fallback URL for the OGC API server, bypassing the per-user server base resolution. If not, it retains the previous behavior of resolving the per-user server base URL.